### PR TITLE
Fix for CSGO

### DIFF
--- a/scripting/chat-processor.sp
+++ b/scripting/chat-processor.sp
@@ -256,11 +256,6 @@ public Action OnSayText2(UserMsg msg_id, BfRead msg, const int[] players, int pl
 			{
 				continue;
 			}
-
-			if (iDeadTalk == 0 && !IsPlayerAlive(i))
-			{
-				continue;
-			}
 		}
 		else
 		{


### PR DESCRIPTION
This check (the one I removed in the commit) prevents dead players from seeing the alive chat. 
By default this is enabled on CS:GO,
Meaning by default, dead players can see alive people chatting.

Which this check was preventing
