### PR TITLE
A bunch of fixes and a couple of additions.

### DIFF
--- a/scripting/chat-processor.sp
+++ b/scripting/chat-processor.sp
@@ -386,26 +386,21 @@ public void Frame_OnChatMessage_SayText2(any data)
 		return;
 	}
 	
-	//Make a copy of the format buffer and use that as the print so the format string stays the same.
-	char sBuffer[MAXLENGTH_BUFFER];
-	strcopy(sBuffer, sizeof(sBuffer), sFormat);
-
+	// CSGO has an issue with adding team colour dots to messages, we have to workaround it.
+	// Unfortunately the colour will be slightly different.
+	// If anyone knows a better way to do this feel free to open a PR.
+	bool bWorkAround = engine == Engine_CSGO && convar_CSGO5v5.BoolValue;
+	
 	//Make sure that the text is default for the message if no colors are present.
 	if (iResults != Plugin_Changed && (!bProcessColors || bRemoveColors))
 	{
 		Format(sMessage, sizeof(sMessage), "\x03%s", sMessage);
 	}
 	
-	// CSGO has an issue with adding team colour dots to messages, we have to workaround it.
-	// Unfortunately the colour will be slightly different.
-	// If anyone knows a better way to do this feel free to open a PR.
+	char szColor[6]; szColor = "\x03";
 	
-	bool bWorkAround = false;
-	
-	if (engine == Engine_CSGO && convar_CSGO5v5.BoolValue) 
+	if (bWorkAround) 
 	{
-		char szColor[6];
-		
 		switch (GetClientTeam(iSender))
 		{
 			case 0, 1:szColor = "\x0E"; // Purple.
@@ -415,9 +410,13 @@ public void Frame_OnChatMessage_SayText2(any data)
 		
 		ReplaceString(sName, sizeof(sName), "\x03", szColor);
 		ReplaceString(sMessage, sizeof(sMessage), "\x03", szColor);
-		
-		bWorkAround = true;
 	}
+	
+	Format(sFormat, sizeof(sFormat), "%s%s\x01", szColor, sFormat);
+	
+	//Make a copy of the format buffer and use that as the print so the format string stays the same.
+	char sBuffer[MAXLENGTH_BUFFER];
+	strcopy(sBuffer, sizeof(sBuffer), sFormat);
 
 	//Replace the specific characters for the name and message strings.
 	ReplaceString(sBuffer, sizeof(sBuffer), "{1}", sName);

--- a/scripting/chat-processor.sp
+++ b/scripting/chat-processor.sp
@@ -249,14 +249,14 @@ public Action OnSayText2(UserMsg msg_id, BfRead msg, const int[] players, int pl
 		{
 			continue;
 		}
+		
+		if (!bAllChat && team != GetClientTeam(i))
+		{
+			continue;
+		}
 
 		if (IsPlayerAlive(iSender))
 		{
-			if (!bAllChat && team != GetClientTeam(i))
-			{
-				continue;
-			}
-
 			if (iDeadTalk == 0 && !IsPlayerAlive(i))
 			{
 				continue;
@@ -270,7 +270,12 @@ public Action OnSayText2(UserMsg msg_id, BfRead msg, const int[] players, int pl
 			}
 		}
 
-		PushArrayCell(hRecipients, i);
+		PushArrayCell(hRecipients, GetClientUserId(i));
+	}
+	
+	if (FindValueInArray(hRecipients, GetClientUserId(iSender)) == -1)
+	{
+		PushArrayCell(hRecipients, GetClientUserId(iSender));
 	}
 
 	//Retrieve the default values for coloring and use these as a base for developers to change later.
@@ -327,7 +332,7 @@ public Action OnSayText2(UserMsg msg_id, BfRead msg, const int[] players, int pl
 	}
 
 	Handle hPack = CreateDataPack();
-	WritePackCell(hPack, iSender);
+	WritePackCell(hPack, GetClientUserId(iSender));
 	WritePackCell(hPack, hRecipients);
 	WritePackString(hPack, sName);
 	WritePackString(hPack, sMessage);
@@ -349,7 +354,7 @@ public void Frame_OnChatMessage_SayText2(any data)
 	//Retrieve pack contents and what not, this part is obvious.
 	ResetPack(data);
 
-	int iSender = ReadPackCell(data);
+	int iSender = GetClientOfUserId(ReadPackCell(data));
 	Handle hRecipients = ReadPackCell(data);
 
 	char sName[MAXLENGTH_NAME];
@@ -371,6 +376,12 @@ public void Frame_OnChatMessage_SayText2(any data)
 	Action iResults = ReadPackCell(data);
 
 	CloseHandle(data);
+	
+	if(!iSender || !IsClientInGame(iSender)) 
+	{
+		delete hRecipients;
+		return;
+	}
 
 	//Make a copy of the format buffer and use that as the print so the format string stays the same.
 	char sBuffer[MAXLENGTH_BUFFER];
@@ -406,9 +417,9 @@ public void Frame_OnChatMessage_SayText2(any data)
 		{
 			for (int i = 0; i < GetArraySize(hRecipients); i++)
 			{
-				int client = GetArrayCell(hRecipients, i);
+				int client = GetClientOfUserId(GetArrayCell(hRecipients, i));
 
-				if (IsClientInGame(client))
+				if (client && IsClientInGame(client))
 				{
 					CSayText2(client, sBuffer, iSender, bChat);
 				}
@@ -418,9 +429,9 @@ public void Frame_OnChatMessage_SayText2(any data)
 		{
 			for (int i = 0; i < GetArraySize(hRecipients); i++)
 			{
-				int client = GetArrayCell(hRecipients, i);
+				int client = GetClientOfUserId(GetArrayCell(hRecipients, i));
 
-				if (IsClientInGame(client))
+				if (client && IsClientInGame(client))
 				{
 					CSetNextAuthor(iSender);
 					CPrintToChat(client, sBuffer);
@@ -471,12 +482,12 @@ public Action OnSayText(UserMsg msg_id, BfRead msg, const int[] players, int pla
 	Handle hRecipients = CreateArray();
 	for (int i = 0; i < playersNum; i++)
 	{
-		PushArrayCell(hRecipients, players[i]);
+		PushArrayCell(hRecipients, GetClientUserId(players[i]));
 	}
 
-	if (FindValueInArray(hRecipients, iSender) == -1)
+	if (FindValueInArray(hRecipients, GetClientUserId(iSender)) == -1)
 	{
-		PushArrayCell(hRecipients, iSender);
+		PushArrayCell(hRecipients, GetClientUserId(iSender));
 	}
 
 	char sName[MAXLENGTH_NAME];
@@ -547,7 +558,7 @@ public Action OnSayText(UserMsg msg_id, BfRead msg, const int[] players, int pla
 	}
 
 	Handle hPack = CreateDataPack();
-	WritePackCell(hPack, iSender);
+	WritePackCell(hPack, GetClientUserId(iSender));
 	WritePackCell(hPack, hRecipients);
 	WritePackString(hPack, sFlag);
 	WritePackString(hPack, sName);
@@ -568,7 +579,7 @@ public void Frame_OnChatMessage_SayText(any data)
 {
 	ResetPack(data);
 
-	int iSender = ReadPackCell(data);
+	int iSender = GetClientOfUserId(ReadPackCell(data));
 
 	Handle hRecipients = ReadPackCell(data);
 
@@ -591,6 +602,12 @@ public void Frame_OnChatMessage_SayText(any data)
 	Action iResults = view_as<Action>(ReadPackCell(data));
 
 	CloseHandle(data);
+	
+	if(!iSender || !IsClientInGame(iSender)) 
+	{
+		delete hRecipients;
+		return;
+	}
 
 	int iTeamColor;
 	switch (GetClientTeam(iSender))
@@ -618,9 +635,9 @@ public void Frame_OnChatMessage_SayText(any data)
 	{
 		for (int i = 0; i < GetArraySize(hRecipients); i++)
 		{
-			int client = GetArrayCell(hRecipients, i);
+			int client = GetClientOfUserId(GetArrayCell(hRecipients, i));
 
-			if (IsClientInGame(client))
+			if (client && IsClientInGame(client))
 			{
 				CSayText2(client, sBuffer, iSender);
 			}

--- a/scripting/include/chat-processor.inc
+++ b/scripting/include/chat-processor.inc
@@ -23,6 +23,26 @@
 **/
 native void ChatProcessor_GetFlagFormatString(const char[] sFlag, char[] sBuffer, int iSize);
 
+/**
+* Adds a recipient to next chat message..
+* You may only use this inside CP_OnChatMessage (Pre) forward.
+*
+* param iClient			Client index to add to recipients.
+*
+* @return				True if client is in the recipients for next message.
+**/
+native bool ChatProcessor_AddRecipient(int iClient);
+
+/**
+* Removes a recipient from next chat message..
+* You may only use this inside CP_OnChatMessage (Pre) forward.
+*
+* param iClient			Client index to remove from recipients.
+*
+* @return				True if client is not in the recipients for next message.
+**/
+native bool ChatProcessor_RemoveRecipient(int iClient);
+
 //Forwards
 /**
 * Called while sending a chat message before It's sent.
@@ -64,6 +84,8 @@ forward void CP_OnChatMessagePost(int author, ArrayList recipients, const char[]
 public void __pl_chat_processor_SetNTVOptional()
 {
 	MarkNativeAsOptional("ChatProcessor_GetFlagFormatString");
+	MarkNativeAsOptional("ChatProcessor_AddRecipient");
+	MarkNativeAsOptional("ChatProcessor_RemoveRecipient");
 }
 #endif
 


### PR DESCRIPTION
**- Fixes:**

- Fix team chat showing to opposite team when a dead player typed.
- Fix formatting not getting correct colours in certain cases such as spectator.
- Fixed invalid statement that checks if text is default or no colours are present.
- Send UserIds in the next frame instead of client indexes.
- Make sure sender is always in the recipients for SayText2.
- Added workaround for annoying dot issue in CSGO when sv_competitive_official_5v5 1. (Colours are slightly different but this will be changed when we figure out the correct colour code / if its possible to fix in a better way)

**- Additions:**

- Added ChatProcessor_AddRecipient - Adds a recipient to next chat message (Must be used inside CP_OnChatMessage (Pre) forward.
- Added ChatProcessor_RemoveRecipient - Removes a recipient from next chat message (Must be used inside CP_OnChatMessage (Pre) forward.
